### PR TITLE
Deploy side-car container with pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,7 @@ RUN apt-get update && apt-get -y install ca-certificates libssl-dev && rm -rf /v
 
 COPY --from=build /build-out/kubes-cd /
 
+ENV SOCKET_ADDRESS=0.0.0.0
+ENV PORT=3030
+
 CMD /kubes-cd

--- a/deployment/kubes-cd.yml
+++ b/deployment/kubes-cd.yml
@@ -46,7 +46,7 @@ metadata:
     app: kubes-cd-controller
   namespace: kubes-cd
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: kubes-cd-controller

--- a/deployment/kubes-cd.yml
+++ b/deployment/kubes-cd.yml
@@ -1,16 +1,22 @@
 ---
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubes-cd
+
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kubes-cd
-  namespace: default
+  namespace: kubes-cd
 automountServiceAccountToken: true
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: default
+  namespace: kubes-cd
   name: kubes-cd
 rules:
 - apiGroups: [""] # "" indicates the core API group
@@ -22,7 +28,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kubes-cd
-  namespace: default
+  namespace: kubes-cd
 roleRef:
   kind: Role
   name: kubes-cd
@@ -38,6 +44,7 @@ metadata:
   name: kubes-cd-deployment
   labels:
     app: kubes-cd-controller
+  namespace: kubes-cd
 spec:
   replicas: 2
   selector:
@@ -64,6 +71,20 @@ spec:
           - name: APPLICATION_ID
             value: "43174"
           - name: NAMESPACE
-            value: "default"
+            value: "kubes-cd"
           - name: RUST_LOG
             value: "debug"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubes-cd-controller
+  namespace: kubes-cd
+spec:
+  selector:
+    app: kubes-cd-controller
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3030

--- a/src/github/client/installation.rs
+++ b/src/github/client/installation.rs
@@ -64,6 +64,8 @@ impl GithubInstallationClient {
             .send()
             .await?;
 
+        info!("Created check run! {:?}", response);
+
         match response.status() {
             StatusCode::CREATED => Ok(()),
             other => Err(other.to_string().into()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,16 +308,18 @@ async fn create_check_run(github_webhook_request: GithubCheckSuiteRequest) -> Re
             check_run_ids.push((step.name.replace(" ", "-").to_lowercase(), checkrun_response.id));
         }
 
+        let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
+
         let pod_deployment = pipeline::generate::generate_kubernetes_pipeline(
             &steps,
             &github_webhook_request.check_suite.head_sha,
             &github_webhook_request.repository.full_name,
             &github_webhook_request.check_suite.head_branch,
             check_run_ids,
+            &namespace
         )?;
 
         let client = Client::infer().await?;
-        let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
         let pods: Api<Pod> = Api::namespaced(client, &namespace);
 

--- a/src/pipeline/generate.rs
+++ b/src/pipeline/generate.rs
@@ -66,7 +66,7 @@ pub fn filter_steps<'a>(steps: &'a[Step], github_branch_name: &String) -> Option
     return Vec1::try_from_vec(maybe_steps).ok();
 }
 
-pub fn generate_kubernetes_pipeline<'a>(steps: &[&'a Step], github_head_sha: &String, repo_name: &String, branch: &String, step_check_id_map: Vec<(String, i32)>) -> Result<Pod, Box<dyn std::error::Error>> {
+pub fn generate_kubernetes_pipeline<'a>(steps: &[&'a Step], github_head_sha: &String, repo_name: &String, branch: &String, step_check_id_map: Vec<(String, i32)>, namespace: &String) -> Result<Pod, Box<dyn std::error::Error>> {
     let mut containers: Vec<serde_json::value::Value> = steps
             .iter()
             .map(|step| {
@@ -117,6 +117,14 @@ pub fn generate_kubernetes_pipeline<'a>(steps: &[&'a Step], github_head_sha: &St
             {
                 "name": "RUST_LOG",
                 "value": "debug"
+            },
+            {
+                "name": "KUBES_CD_CONTROLLER_BASE_URL",
+                "value": "http://kubes-cd-controller"
+            },
+            {
+                "name": "NAMESPACE",
+                "value": namespace
             }
         ]
     }));
@@ -152,7 +160,8 @@ pub fn generate_kubernetes_pipeline<'a>(steps: &[&'a Step], github_head_sha: &St
                 "branch": branch,
                 "commit": short_commit,
                 "app": "kubes-cd-test"
-            }
+            },
+            "namespace": namespace
         },
         "spec": {
             "initContainers": [{

--- a/src/pipeline/generate.rs
+++ b/src/pipeline/generate.rs
@@ -66,7 +66,7 @@ pub fn filter_steps<'a>(steps: &'a[Step], github_branch_name: &String) -> Option
     return Vec1::try_from_vec(maybe_steps).ok();
 }
 
-pub fn generate_kubernetes_pipeline<'a>(steps: &[&'a Step], github_head_sha: &String, repo_name: &String, branch: &String, step_check_id_map: Vec<(String, i32)>, namespace: &String) -> Result<Pod, Box<dyn std::error::Error>> {
+pub fn generate_kubernetes_pipeline<'a>(steps: &[&'a Step], github_head_sha: &String, repo_name: &String, branch: &String, step_check_id_map: Vec<(String, i32)>, namespace: &String, installation_id: u32) -> Result<Pod, Box<dyn std::error::Error>> {
     let mut containers: Vec<serde_json::value::Value> = steps
             .iter()
             .map(|step| {
@@ -119,12 +119,20 @@ pub fn generate_kubernetes_pipeline<'a>(steps: &[&'a Step], github_head_sha: &St
                 "value": "debug"
             },
             {
+                "name": "INSTALLATION_ID",
+                "value": installation_id.to_string()
+            },
+            {
                 "name": "KUBES_CD_CONTROLLER_BASE_URL",
                 "value": "http://kubes-cd-controller"
             },
             {
                 "name": "NAMESPACE",
                 "value": namespace
+            },
+            {
+                "name": "REPO_NAME",
+                "value": repo_name
             }
         ]
     }));

--- a/src/pipeline/generate.rs
+++ b/src/pipeline/generate.rs
@@ -66,7 +66,7 @@ pub fn filter_steps<'a>(steps: &'a[Step], github_branch_name: &String) -> Option
     return Vec1::try_from_vec(maybe_steps).ok();
 }
 
-pub fn generate_kubernetes_pipeline<'a>(steps: &[&'a Step], github_head_sha: &String, repo_name: &String, branch: &String) -> Result<Pod, Box<dyn std::error::Error>> {
+pub fn generate_kubernetes_pipeline<'a>(steps: &[&'a Step], github_head_sha: &String, repo_name: &String, branch: &String, step_check_id_map: Vec<(String, i32)>) -> Result<Pod, Box<dyn std::error::Error>> {
     let containers: Vec<serde_json::value::Value> = steps
             .iter()
             .map(|step| {
@@ -95,8 +95,15 @@ pub fn generate_kubernetes_pipeline<'a>(steps: &[&'a Step], github_head_sha: &St
                 });
             }).collect();
 
-    info!("Containers to deploy: {}", json!(containers));
+    let step_check_id_map_env: String = step_check_id_map
+        .iter()
+        .map(|map| format!("{}={}", map.0, map.1))
+        .collect::<Vec<String>>()
+        .join(",");
 
+    info!("Check run ids to step map {}", step_check_id_map_env);
+
+    info!("Containers to deploy: {}", json!(containers));
 
     let clone_url = format!("https://github.com/{}", repo_name);
 


### PR DESCRIPTION
Deploys a side-car container that runs alongside the steps that are running within the pipeline. This allows the process to become asynchronous and not rely on the controller having to respond to Github in time (which is important for long running tasks such as releasing a build). The side-car is only ~30mb, so has a pretty small overhead.